### PR TITLE
Add exe creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
+bin/
 *.py[cod]
 
 .idea/

--- a/rotostitch/__init__.py
+++ b/rotostitch/__init__.py
@@ -1,6 +1,7 @@
 import os
+import sys
 
 __version__ = "1.0.0"
 
-packageDir, __ = os.path.split(__file__)
-RESOURCE_DIR = os.path.join(packageDir, "resources")
+packageDir = os.path.dirname(sys.argv[0])
+RESOURCE_DIR = os.path.join(os.path.abspath(packageDir), "resources")

--- a/rotostitch/main.py
+++ b/rotostitch/main.py
@@ -40,7 +40,7 @@ class Application(tkinter.Tk):
         menuBar.add_cascade(label="About", menu=aboutMenu)
 
         # Window Setup
-        self.title("RotaStitch")
+        self.title("Rotostitch")
         self.config(menu=menuBar)
         self.iconbitmap(default=os.path.join(RESOURCE_DIR, "rotostitch-icon.ico"))
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,53 @@
+#! /usr/bin/python3.4-32
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import distutils.dir_util
+from cx_Freeze import (setup, Executable)
+
+base = None
+
+# Windows
+if sys.platform == "win32":
+    base = "Win32GUI"
+
+    # x86 Python/exe
+    if sys.maxsize < 2 ** 32:
+        destfolder = os.path.join("bin", "Windows", "x86")
+
+    # x64 Python/exe
+    else:
+        destfolder = os.path.join("bin", "Windows", "x64")
+
+# Mac OS X
+elif sys.platform == "darwin":
+    destfolder = os.path.join("bin", "Mac OS X")
+
+# Linux
+else:
+    destfolder = os.path.join("bin", "Linux")
+
+# Create the freeze path if it doesn't exist
+if not os.path.exists(destfolder):
+    os.makedirs(destfolder)
+
+# Copy required files
+build_exe_options = {
+    "build_exe": destfolder,
+    "icon": "rotostitch/resources/rotostitch-icon.ico"
+}
+
+distutils.dir_util.copy_tree(os.path.join("rotostitch", "resources"),
+                             os.path.join(destfolder, "resources"))
+
+setup(
+    name="Rotostitch",
+    version="1.0.0",
+    author="AnW",
+    description="Rotostitch",
+    license="MIT License",
+    options={"build_exe": build_exe_options},
+    executables=[Executable("Rotostitch.pyw",
+                 targetName="Rotostitch.exe", base=base)]
+)


### PR DESCRIPTION
Hi. I'm @rioforce's brother. He [mentioned me](http://www.bricksinmotion.com/forums/post/342119/#p342119) in your topic on BiM. :)

This pull request (also known as PR) adds requested support for creating an exe. As you are using Python 3, the best utility for this job is using [cx_Freeze](http://cx-freeze.sourceforge.net/). After merging this, all you have to do to create the exe is run `setup.py build` and it will be created. 

I should note that you will ideally want to be running the 32-bit version of Python for freezing. The Python version you use determines the version of exe produced. x86 Python only makes x86 exes, and x64 Python only makes x64 exes.

I would advise to not check the produced files into version control. When you make a release, create a zip archive of them and upload them using the Releases feature. :)

I had to make minor changes to support freezing the exe, but it all should still work. I also fixed a minor typo in the window title.

Please review these changes and let me know of anything I need to fix. If you're concerned about me "not knowing what I'm doing", feel free to browse my repos. I have 2 years of Python experience and a number of Python applications of varying complexity and abilities under my belt. :)
